### PR TITLE
Add get to an array element by index, syntax is foo.bar[n]

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ continuous development steps.
 ## Get a value
 
 `toml get --toml-path pyproject.toml tool.poetry.name`
+`toml get --toml-path pyproject.toml tool.poetry.authors[0]`
 
 ## Set a value
 

--- a/tests/toml_cli/test_init.py
+++ b/tests/toml_cli/test_init.py
@@ -57,6 +57,8 @@ name = "University"
 
     assert get(["get", "--toml-path", str(test_toml_path), "person.age"]) == "12"
 
+    assert get(["get", "--toml-path", str(test_toml_path), "person.addresses[1]"]) == "Amsterdam"
+
 
 def test_set_value(tmp_path: pathlib.Path):
     test_toml_path = tmp_path / "test.toml"

--- a/toml_cli/__init__.py
+++ b/toml_cli/__init__.py
@@ -5,6 +5,7 @@ from typing import Optional
 import tomlkit
 import tomlkit.exceptions
 import typer
+import re
 
 app = typer.Typer(no_args_is_help=True)
 
@@ -19,7 +20,13 @@ def get(
 
     if key is not None:
         for key_part in key.split("."):
-            toml_part = toml_part[key_part]
+            match = re.search(r"(?P<key>.*?)\[(?P<index>\d+)\]", key_part)
+            if match:
+                key = match.group("key")
+                index = int(match.group("index"))
+                toml_part = toml_part[key][index]
+            else:
+                toml_part = toml_part[key_part]
 
     typer.echo(toml_part)
 


### PR DESCRIPTION
The get command lacks the access to an array element by index. The proposed patch adds this feature. 

example:
`toml get --toml-path pyproject.toml tool.poetry.authors[0]`