### PR TITLE
fix: 'get' command on array of tables

### DIFF
--- a/tests/toml_cli/test_init.py
+++ b/tests/toml_cli/test_init.py
@@ -32,6 +32,14 @@ addresses = ["Rotterdam", "Amsterdam"]
 
 [person.education]
 name = "University"
+
+[[person.vehicles]]
+model = "Golf"
+year = 2020
+
+[[person.vehicles]]
+model = "Prius"
+year = 2016
 """
     )
 
@@ -42,7 +50,8 @@ name = "University"
 
     assert get(["get", "--toml-path", str(test_toml_path), "person"]) == (
         "{'name': 'MyName', 'age': 12, 'happy': False, "
-        "'addresses': ['Rotterdam', 'Amsterdam'], 'education': {'name': 'University'}}"
+        "'addresses': ['Rotterdam', 'Amsterdam'], 'education': {'name': 'University'}, "
+        "'vehicles': [{'model': 'Golf', 'year': 2020}, {'model': 'Prius', 'year': 2016}]}"
     )
 
     assert get(["get", "--toml-path", str(test_toml_path), "person.education"]) == "{'name': 'University'}"
@@ -51,7 +60,20 @@ name = "University"
 
     assert get(["get", "--toml-path", str(test_toml_path), "person.age"]) == "12"
 
+    assert get(["get", "--toml-path", str(test_toml_path), "person.addresses"]) == "['Rotterdam', 'Amsterdam']"
+
     assert get(["get", "--toml-path", str(test_toml_path), "person.addresses[1]"]) == "Amsterdam"
+
+    assert get(["get", "--toml-path", str(test_toml_path), "person.vehicles"]) == (
+        "["
+            "{'model': 'Golf', 'year': 2020}, "
+            "{'model': 'Prius', 'year': 2016}"
+        "]"
+    )
+
+    assert get(["get", "--toml-path", str(test_toml_path), "person.vehicles[1]"]) == "{'model': 'Prius', 'year': 2016}"
+
+    assert get(["get", "--toml-path", str(test_toml_path), "person.vehicles[1].model"]) == "Prius"
 
 
 def test_set_value(tmp_path: pathlib.Path):

--- a/toml_cli/__init__.py
+++ b/toml_cli/__init__.py
@@ -28,7 +28,7 @@ def get(
             else:
                 toml_part = toml_part[key_part]
 
-    typer.echo(toml_part)
+    typer.echo(toml_part.unwrap())
 
 
 @app.command("set")


### PR DESCRIPTION
'Getting' an array of tables would print a tomlkit object, namely a [`tomlkit.items.AoT`](https://tomlkit.readthedocs.io/en/latest/api/#tomlkit.items.AoT), instead of printing a json string.

```sh
$ toml get person.vehicles
<AoT [{'model': 'Golf', 'year': 2020}, {'model': 'Prius', 'year': 2016}]>
```

The easiest way I could find to cover all tests was to convert the `tomlkit.items.*` object into their pure python object with `.unwrap()` and print that instead.