### PR TITLE
fix: let 'set' command fail on key not found

### DIFF
--- a/tests/toml_cli/test_init.py
+++ b/tests/toml_cli/test_init.py
@@ -68,6 +68,9 @@ name = "University"
 """
     )
 
+    result = runner.invoke(app, ["set", "--toml-path", str(test_toml_path), "person.KEY_THAT_DOES_NOT_EXIST.name", "15"])
+    assert result.exit_code == 1
+
     result = runner.invoke(app, ["set", "--toml-path", str(test_toml_path), "person.age", "15"])
     assert result.exit_code == 0
     assert 'age = "15"' in test_toml_path.read_text()

--- a/toml_cli/__init__.py
+++ b/toml_cli/__init__.py
@@ -51,7 +51,8 @@ def set_(
         try:
             toml_part = toml_part[key_part]
         except tomlkit.exceptions.NonExistentKey:
-            typer.echo(f"Key {key} can not set", err=True)
+            typer.echo(f"error: non-existent key '{key}' can not be set to value '{value}'", err=True)
+            exit(1)
 
     if to_int:
         value = int(value)


### PR DESCRIPTION
Whenever a key is not found within a 'set' command. The command should error out instead of trying to continue execution and assign the value to a partially parsed key.

Example:
`toml set --toml-path pyproject.toml tool.ruffs.target-version py39`

The table `tool.ruffs` does not exist but the current implementation captures this exception and continues along, actually executing `tool.target-version = "py39"`.

I believe a better implementation is to not capture the exception at all and error out, this way no unintended modifications to the TOML file are performed.

Another option is to continue capturing the exception but error out using `exit(1)`.

What do you think?