### PR TITLE
feat: add support for setting array element

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ continuous development steps.
 ## Set a value
 
 `toml set --toml-path pyproject.toml tool.poetry.version 0.2.0`
+`toml set --toml-path pyproject.toml tool.poetry.authors[0] "Marc Rijken <marc@rijken.org>"`
 
 ## Add a section
 

--- a/tests/toml_cli/test_init.py
+++ b/tests/toml_cli/test_init.py
@@ -62,6 +62,7 @@ def test_set_value(tmp_path: pathlib.Path):
 name = "MyName"
 happy = false
 age = 12
+skills = ["python", "pip"]
 
 [person.education]
 name = "University"
@@ -114,6 +115,10 @@ name = "University"
     )
     assert result.exit_code == 0
     assert 'addresses = ["Amsterdam", "London"]' in test_toml_path.read_text()
+
+    result = runner.invoke(app, ["set", "--toml-path", str(test_toml_path), "person.skills[1]", "toml"])
+    assert result.exit_code == 0
+    assert 'skills = ["python", "toml"]' in test_toml_path.read_text()
 
 
 def test_add_section(tmp_path: pathlib.Path):

--- a/toml_cli/__init__.py
+++ b/toml_cli/__init__.py
@@ -62,7 +62,14 @@ def set_(
     if to_array:
         value = json.loads(value)
 
-    toml_part[key.split(".")[-1]] = value
+    last_key = key.split(".")[-1]
+    match = re.search(r"(?P<table>.*?)\[(?P<index>\d+)\]", last_key)
+    if match:
+        table = match.group("table")
+        index = int(match.group("index"))
+        toml_part[table][index] = value
+    else:
+        toml_part[last_key] = value
 
     toml_path.write_text(tomlkit.dumps(toml_file))
 


### PR DESCRIPTION
Currently, the 'set' command lacks the access to an array element by index. This patch adds this feature.

Example: `toml set --toml-path pyproject.toml tool.poetry.authors[0] "Marc Rijken <marc@rijken.org>"`