### PR TITLE
fix: Fix assertion in JMESPath test after bumping typer

### DIFF
--- a/tests/toml_cli/test_init.py
+++ b/tests/toml_cli/test_init.py
@@ -143,7 +143,7 @@ year = 2016
 
     result = runner.invoke(app, ["search", "--toml-path", str(test_toml_path), "wrong-expression"])
     assert result.exit_code == 1
-    assert "error: invalid jmespath expression" in result.stdout
+    assert "error: invalid jmespath expression" in result.stderr
 
 
 def test_set_value(tmp_path: pathlib.Path):


### PR DESCRIPTION
Hi Marc,
I have run the tests locally after you have merged my changes, and one of the assertions in my unit test is now broken (on master!) since `typer` in the newer version that you have bumped does not send errors to `stdout`, now - after your changes - it only sends it to `stderr`.

So I have prepared a simple fix.
Please note that the code should work, but the test fails, and this is a false negative, so should be fixed.

ANOTHER issue FYI: the poetry lock file requires to be refreshed. Right now it is "broken", since I have resolved conflicts there without doing that through `poetry` itself, and the `metadata-hash` seems to be outdated. To fix it, you have to run `poetry lock` and refresh the file. But on my machine, even when using the same version of Poetry as you are using, `poetry` is not only setting up a correct `metadata.content-hash` (which is "broken" now after manually fixing the conflicts in PR39), but also removing some windows-related stuff since I work on arch.

The questions is: is it actually an issue? And do you really want to keep the poetry.lock file in the repository, maybe the `pyproject.toml` is enough? 